### PR TITLE
(fix) goto-today: can not goto today note directly(#2134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Removed
 ### Fixed
 - [#2130](https://github.com/org-roam/org-roam/pull/2130) buffer: unlinked-references section now also searches within symlinked directories
+- [#2134](https://github.com/org-roam/org-roam/issues/2134) goto: fix `org-roam-dailies-goto-today` can not goto today's note.
 
 ### Changed
 

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -469,11 +469,11 @@ capture target."
   (let ((id (cond ((run-hook-with-args-until-success 'org-roam-capture-preface-hook))
                   (t (org-roam-capture--setup-target-location)))))
     (org-roam-capture--adjust-point-for-capture-type)
-    (let ((template (org-capture-get :template)))
-      (when (stringp template)
-        (org-capture-put
-         :template
-         (org-roam-capture--fill-template template))))
+    ;; (let ((template (org-capture-get :template)))
+    ;;   (when (stringp template)
+    ;;     (org-capture-put
+    ;;      :template
+    ;;      (org-roam-capture--fill-template template))))
     (org-roam-capture--put :id id)
     (org-roam-capture--put :finalize (or (org-capture-get :finalize)
                                          (org-roam-capture--get :finalize)))))


### PR DESCRIPTION
It is not nessesary to use `org-roam-capture--fill-template` to fill template when I
call `org-capture-set-target-location'.

changed:     CHANGELOG.md
changed:     org-roam-capture.el

###### Motivation for this change
